### PR TITLE
Web split node selector

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -157,6 +157,9 @@ spec:
               node_selector:
                 description: nodeSelector for the pods
                 type: string
+              web_node_selector:
+                description: web deployment nodeSelector for the pods
+                type: string
               topology_spread_constraints:
                 description: topology rule(s) for the pods
                 type: string

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -602,6 +602,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Node Selector
+        path: web_node_selector
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Topology Spread Constraints
         path: topology_spread_constraints
         x-descriptors:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -70,6 +70,14 @@ hostname: ''
 #   kubernetes.io/os: linux
 node_selector: ''
 
+# Add a nodeSelector for the web AWX pods. It must match a node's labels for the pod
+# to be scheduled on that node. Specify as literal block. E.g.:
+# web_node_selector: |
+#   disktype: ssd
+#   kubernetes.io/arch: amd64
+#   kubernetes.io/os: linux
+web_node_selector: ''
+
 # Add a topologySpreadConstraints for the AWX pods.
 # Specify as literal block. E.g.:
 # topology_spread_constraints: |

--- a/roles/installer/tasks/resources_configuration.yml
+++ b/roles/installer/tasks/resources_configuration.yml
@@ -205,6 +205,14 @@
   set_fact:
     _redis_image: "{{ _custom_redis_image | default(lookup('env', 'RELATED_IMAGE_AWX_REDIS')) | default(_default_redis_image, true) }}"
 
+# use default node_selector if set, otherwise use defaults/main.yaml value
+- name: Set web_node_selector value
+  set_fact:
+    web_node_selector: {{ node_selector }}
+  when:
+    - node_selector | default('') | length
+    - web_node_selector is not defined
+
 - name: Apply deployment resources
   k8s:
     apply: yes

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -182,6 +182,10 @@ spec:
             - name: AWX_KUBE_DEVEL
               value: "1"
 {% endif %}
+{% if node_selector %}
+      nodeSelector:
+        {{ web_node_selector | indent(width=8) }}
+{% endif %}
 {% if web_extra_env -%}
             {{ web_extra_env | indent(width=12, first=True) }}
 {% endif %}


### PR DESCRIPTION
##### SUMMARY

Hacking session to split out node_selector setting for web and task deployments.  

This will result in two new settings on the AWX CRD:
* web_node_selector
* task_node_selector
* node_selector (remains, tbd if we mark it as deprecated or not)

Whether we deprecate `node_selector` or not, if web_node_selector or task_node_selector are not set, we should use the `node_selector` values.  

> Note: even if we decide to remove node_selector, it needs to stay on the AWX CRD so that upgrades still work for customers that have `node_selector` currently set on their AWX spec.  

The precedence order for this setting's value should be:
* web_node_selector set explicitly on AWX spec
* node_selector set explicitly on AWX spec
* node_selector `roles/installer/defaults/main.yaml`

**Steps:**
- [ ] Add CRD entry for new web_node_selector setting
- [ ] ~Add default value in `roles/installer/defaults/main.yml`~  - I think we should leave this out as node_selector already has a default value.
- [ ] Add logic in roles/installer/resources
- [ ] Add Openshift UI params
- [ ] Update README.md Docs

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION

**Testing Criteria**

- [ ] Create an AWX object with web_node_selector set.  Make sure validators don't complain at creation time.

```
---
apiVersion: awx.ansible.com/v1beta1
kind: AWX
metadata:
  name: awx-demo-2
spec:
  no_log: false
  web_node_selector: |
    disktype: ssd
    kubernetes.io/arch: amd64
    kubernetes.io/os: linux

  # node_selector: |
  #   disktype: ssd
  #   kubernetes.io/arch: amd64
  #   kubernetes.io/os: linux
  service_type: nodeport
  ingress_type: ingress

```

- [ ] Ensure that after the values set in the yaml are on the resulting web deployment object.
- [ ] Create an AWX object with `node_selector` set, without setting `web_node_selector` and make sure the node_selector value gets set for the web deployment.  (will need to modify the selector from the default for node_selector setting defaults/main.yml